### PR TITLE
fix: update canonical URL

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -69,7 +69,7 @@ module.exports = {
     titleTemplate: '%s | TJCSC',
     description:
       'TJHSST Computer Security Club is designed to introduce students to ethical hacking',
-    url: 'https://activities.tjhsst.edu',
+    url: 'https://tjcsec.club',
     menuLinks: [
       {
         name: 'Presentations',


### PR DESCRIPTION
helps search engines show the right site

you may also want to set up a redirect on the old activities.tjhsst.edu/csc url for a while so that links aren't broken